### PR TITLE
Clarify little-endian save format

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ cromulent_load(&state, buffer);
 // Continue generating the same sequence from this point
 ```
 
+`cromulent_save` writes the two 64-bit words of the PRNG state in
+little-endian byte order.  The data in `buffer` is therefore portable
+between platforms with different native endianness.
+
 ### Using the Generator Registry
 
 The library maintains a registry system primarily for internal benchmarking and testing, but it can also be used in applications:

--- a/include/cromulent.h
+++ b/include/cromulent.h
@@ -39,7 +39,9 @@ double cromulent_double(cromulent_state *state);
 float cromulent_float(cromulent_state *state);
 void cromulent_jump(cromulent_state *state);
 uint64_t cromulent_range(cromulent_state *state, uint64_t n);
+// Save the PRNG state to a 16-byte buffer in little-endian order
 void cromulent_save(const cromulent_state *state, uint8_t *buffer);
+// Load the state from a 16-byte buffer written by cromulent_save
 void cromulent_load(cromulent_state *state, const uint8_t *buffer);
 const CromulentPRNG *cromulent_registry_find(const char *name);
 const CromulentPRNG *cromulent_registry_all(size_t *count_out);

--- a/src/scalar/cromulent_scalar.c
+++ b/src/scalar/cromulent_scalar.c
@@ -2,6 +2,22 @@
 
 #include "cromulent.h"
 
+static void store_le64(uint8_t *out, uint64_t x) {
+  for (int i = 0; i < 8; i++) {
+    out[i] = (uint8_t)(x & 0xff);
+    x >>= 8;
+  }
+}
+
+static uint64_t load_le64(const uint8_t *in) {
+  uint64_t x = 0;
+  for (int i = 7; i >= 0; i--) {
+    x <<= 8;
+    x |= in[i];
+  }
+  return x;
+}
+
 void cromulent_init(cromulent_state *state, const uint64_t seed) {
   uint64_t z = seed;
 
@@ -109,11 +125,11 @@ uint64_t cromulent_range(cromulent_state *state, uint64_t n) {
 }
 
 void cromulent_save(const cromulent_state *state, uint8_t *buffer) {
-  memcpy(buffer, &state->s0, sizeof(uint64_t));
-  memcpy(buffer + sizeof(uint64_t), &state->s1, sizeof(uint64_t));
+  store_le64(buffer, state->s0);
+  store_le64(buffer + sizeof(uint64_t), state->s1);
 }
 
 void cromulent_load(cromulent_state *state, const uint8_t *buffer) {
-  memcpy(&state->s0, buffer, sizeof(uint64_t));
-  memcpy(&state->s1, buffer + sizeof(uint64_t), sizeof(uint64_t));
+  state->s0 = load_le64(buffer);
+  state->s1 = load_le64(buffer + sizeof(uint64_t));
 }


### PR DESCRIPTION
## Summary
- document that `cromulent_save` writes bytes in little-endian order
- note endianness in header comments
- explicitly encode/decode state in little-endian form

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6840c253f8c8832889d10755f2c10b9e