### PR TITLE
Add AVX2 SIMD functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,17 @@ set(CROMULENT_SRCS
     src/reference/xoshiro256.c
 )
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-mavx2 HAS_AVX2)
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" AND HAS_AVX2)
     list(APPEND CROMULENT_SRCS src/simd/cromulent_avx2.c)
 endif ()
 
 add_library(cromulent STATIC ${CROMULENT_SRCS})
 target_include_directories(cromulent PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" AND HAS_AVX2)
     target_compile_options(cromulent PRIVATE -mavx2)
 endif ()
 

--- a/include/cromulent.h
+++ b/include/cromulent.h
@@ -31,6 +31,9 @@ typedef struct {
 typedef struct {
   __m256i s0, s1;
 } cromulent_avx2_state;
+
+void cromulent_avx2_init(cromulent_avx2_state *state, uint64_t seed);
+__m256i cromulent_avx2_next(cromulent_avx2_state *state);
 #endif
 
 void cromulent_init(cromulent_state *state, uint64_t seed);

--- a/include/internal.h
+++ b/include/internal.h
@@ -25,11 +25,20 @@ static inline __m256i rotl_avx2(__m256i x, int k) {
   return _mm256_or_si256(_mm256_slli_epi64(x, k), _mm256_srli_epi64(x, 64 - k));
 }
 
+static inline __m256i mullo_epi64_avx2(__m256i a, __m256i b) {
+  __m256i albl = _mm256_mul_epu32(a, b);
+  __m256i albh = _mm256_mul_epu32(a, _mm256_srli_epi64(b, 32));
+  __m256i ahbl = _mm256_mul_epu32(_mm256_srli_epi64(a, 32), b);
+  __m256i cross = _mm256_add_epi64(albh, ahbl);
+  cross = _mm256_slli_epi64(cross, 32);
+  return _mm256_add_epi64(albl, cross);
+}
+
 static inline __m256i mix_avx2(__m256i x) {
   x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
-  x = _mm256_mullo_epi64(x, _mm256_set1_epi64x(0xff51afd7ed558ccdULL));
+  x = mullo_epi64_avx2(x, _mm256_set1_epi64x(0xff51afd7ed558ccdULL));
   x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
-  x = _mm256_mullo_epi64(x, _mm256_set1_epi64x(0xc4ceb9fe1a85ec53ULL));
+  x = mullo_epi64_avx2(x, _mm256_set1_epi64x(0xc4ceb9fe1a85ec53ULL));
   x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
   return x;
 }

--- a/src/simd/cromulent_avx2.c
+++ b/src/simd/cromulent_avx2.c
@@ -3,23 +3,37 @@
 #if defined(__AVX2__)
 #include "cromulent.h"
 
-static inline __m256i cromulent_avx2_next(cromulent_avx2_state *state) {
+void cromulent_avx2_init(cromulent_avx2_state *state, uint64_t seed) {
+  uint64_t z = seed;
+  uint64_t buf[8];
+
+  for (int i = 0; i < 8; ++i) {
+    z += C1;
+    z = (z ^ (z >> 30)) * C2;
+    z = (z ^ (z >> 27)) * C3;
+    buf[i] = z ^ (z >> 31);
+  }
+
+  state->s0 = _mm256_set_epi64x(buf[3], buf[2], buf[1], buf[0]);
+  state->s1 = _mm256_set_epi64x(buf[7], buf[6], buf[5], buf[4]);
+}
+
+__m256i cromulent_avx2_next(cromulent_avx2_state *state) {
   __m256i s0 = state->s0;
   __m256i s1 = state->s1;
 
-  // Parallel state update
-  state->s0 = _mm256_add_epi64(
-      _mm256_mullo_epi64(s0, _mm256_set1_epi64x(0xd1342543de82ef95ULL)), s1);
-
+  state->s0 =
+      _mm256_add_epi64(mullo_epi64_avx2(s0, _mm256_set1_epi64x(0xd1342543de82ef95ULL)),
+                       s1);
   state->s1 = _mm256_add_epi64(rotl_avx2(s1, 31), mix_avx2(s0));
 
-  // Output mixing
   __m256i result = _mm256_add_epi64(s0, rotl_avx2(s1, 11));
   result = _mm256_xor_si256(result, _mm256_srli_epi64(result, 27));
   result =
-      _mm256_mullo_epi64(result, _mm256_set1_epi64x(0x94d049bb133111ebULL));
+      mullo_epi64_avx2(result, _mm256_set1_epi64x(0x94d049bb133111ebULL));
   result = _mm256_xor_si256(result, _mm256_srli_epi64(result, 27));
 
   return result;
 }
-#endif
+
+#endif // __AVX2__


### PR DESCRIPTION
## Summary
- implement cromulent_avx2_init/next functions
- expose AVX2 API in header
- add AVX2 multiplication helper for mix function
- compile SIMD code only when AVX2 flag is available

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6840c2530ae4832895a60e17d35ed931