### PR TITLE
Implement cromulent_strong_init

### DIFF
--- a/include/cromulent.h
+++ b/include/cromulent.h
@@ -34,6 +34,7 @@ typedef struct {
 #endif
 
 void cromulent_init(cromulent_state *state, uint64_t seed);
+void cromulent_strong_init(cromulent_strong_state *st, uint64_t seed);
 uint64_t cromulent_next(cromulent_state *state);
 double cromulent_double(cromulent_state *state);
 float cromulent_float(cromulent_state *state);

--- a/src/scalar/cromulent_strong.c
+++ b/src/scalar/cromulent_strong.c
@@ -22,3 +22,17 @@ uint64_t cromulent_strong_next(cromulent_strong_state *state) {
 
   return mix_fast(output);
 }
+
+void cromulent_strong_init(cromulent_strong_state *st, uint64_t seed) {
+  uint64_t z = seed;
+
+  z += C1;
+  z = (z ^ (z >> 30)) * C2;
+  z = (z ^ (z >> 27)) * C3;
+  st->a = z ^ (z >> 31);
+
+  z += C1;
+  z = (z ^ (z >> 30)) * C2;
+  z = (z ^ (z >> 27)) * C3;
+  st->b = z ^ (z >> 31);
+}


### PR DESCRIPTION
## Summary
- initialize the strong PRNG state with the same scheme as cromulent_init
- expose `cromulent_strong_init` in the public header

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840c252af108328acc0a3808bd15377