### PR TITLE
Fix bench_micro seed printf formatting

### DIFF
--- a/apps/bench_micro.c
+++ b/apps/bench_micro.c
@@ -2,6 +2,7 @@
 
 #include "cromulent.h"
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <time.h>
 
@@ -36,7 +37,7 @@ void benchmark(const char *name, void (*init)(uint64_t), uint64_t (*next)(void),
 int main(void) {
   uint64_t seed = 69420;
 
-  printf("running %llu samples with seed %ld\n", NUM_SAMPLES, seed);
+  printf("running %llu samples with seed %" PRIu64 "\n", NUM_SAMPLES, seed);
   benchmark("xoshiro256", init_xoshiro, xoshiro256pp, seed);
   benchmark("cromulent128", init_cromulent, cromulent128pp, seed);
   benchmark("splitmix64", init_splitmix64, splitmix64pp, seed);


### PR DESCRIPTION
## Summary
- include `<inttypes.h>` to use PRIu64 macros
- print the benchmark seed with PRIu64 so it works on all platforms

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6840c251047083288f95cfa95ede43f3