### PR TITLE
Improve PCG64 seeding

### DIFF
--- a/src/reference/pcg64.c
+++ b/src/reference/pcg64.c
@@ -6,10 +6,9 @@ static uint64_t pcg_state = 0x853c49e6748fea9bULL;
 static uint64_t pcg_inc = 0xda3e39cb94b95bdbULL;
 
 void init_pcg64(uint64_t seed) {
-  pcg_state = 0;
-  pcg_inc = (seed << 1u) | 1u;
-  splitmix64pp();
-  pcg_state += seed;
+  init_splitmix64(seed);
+  pcg_state = splitmix64pp();
+  pcg_inc = splitmix64pp() | 1u;
 }
 
 uint64_t pcg64pp(void) {


### PR DESCRIPTION
## Summary
- follow standard PCG seeding
- derive state and stream using splitmix64

## Testing
- `cmake ..`
- `make -j4`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6840c250ea5c832883ffd39d6545b68e