### PR TITLE
Fix practrand test script

### DIFF
--- a/tests/stats/practrand.sh
+++ b/tests/stats/practrand.sh
@@ -1,1 +1,5 @@
-build/dump_raw | practrand/RNG_test stdin64 -tlmax 128TB -a -multithreaded | tee tests/results/practrand128TB.txt
+#!/bin/sh
+set -e
+
+build/dump_raw | practrand/RNG_test stdin64 -tlmax 128TB -a -multithreaded |
+    tee tests/results/practrand128TB.txt


### PR DESCRIPTION
## Summary
- standardize line endings of `tests/stats/practrand.sh`
- add a proper shebang and `set -e`
- make the script executable

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68596a00a7808328ace96d667c8de300