### PR TITLE
Remove unused SC2 constant

### DIFF
--- a/include/internal.h
+++ b/include/internal.h
@@ -16,7 +16,6 @@
 #define C6 0xd1342543de82ef95ULL
 
 #define SC1 0x3b22c4a0c50de29bULL
-#define SC2 0x5e4d93b362c7f62aULL
 
 #define MH3 0xd6e8feb86659fd93ULL
 


### PR DESCRIPTION
## Summary
- drop unused `SC2` constant

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685969fd06c48328814bd29de43a1eb7