### PR TITLE
Expose strong generator in public API

### DIFF
--- a/include/cromulent.h
+++ b/include/cromulent.h
@@ -38,6 +38,7 @@ __m256i cromulent_avx2_next(cromulent_avx2_state *state);
 
 void cromulent_init(cromulent_state *state, uint64_t seed);
 void cromulent_strong_init(cromulent_strong_state *st, uint64_t seed);
+uint64_t cromulent_strong_next(cromulent_strong_state *state);
 uint64_t cromulent_next(cromulent_state *state);
 double cromulent_double(cromulent_state *state);
 float cromulent_float(cromulent_state *state);

--- a/tests/unit/strong_next.c
+++ b/tests/unit/strong_next.c
@@ -9,9 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// cromulent_strong_next is not declared in the public header
-extern uint64_t cromulent_strong_next(cromulent_strong_state *state);
-
 // For simplicity, define a check macro that prints error info
 #define CHECK(cond, msg) do { \
     if (!(cond)) { \


### PR DESCRIPTION
## Summary
- add cromulent_strong_next prototype to public header
- remove manual extern from strong_next test

## Testing
- `cmake .. && make`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_6893c44e3dd883288ef801684f886985