### PR TITLE
Include strong_next test in check target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,6 @@ add_subdirectory(tests/unit)
 
 add_custom_target(check
     COMMAND ${CMAKE_CTEST_COMMAND} -V
-    DEPENDS sanity test_jump test_save test_load
+    DEPENDS sanity test_jump test_save test_load test_strong_next
     COMMENT "Running all tests (sanity and unit tests)"
 )


### PR DESCRIPTION
## Summary
- ensure the `check` target depends on `test_strong_next`

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build check`
- `cmake -S . -B build-make -G "Unix Makefiles"`
- `cmake --build build-make --target check`


------
https://chatgpt.com/codex/tasks/task_e_6893c4539f3083288831709a34d6b4c9