### PR TITLE
Guard cromulent_range against zero

### DIFF
--- a/src/scalar/cromulent_scalar.c
+++ b/src/scalar/cromulent_scalar.c
@@ -109,6 +109,9 @@ void cromulent_jump(cromulent_state *state) {
 
 #ifdef __SIZEOF_INT128__
 uint64_t cromulent_range(cromulent_state *state, uint64_t n) {
+  // Generate a uniform random number in [0, n). Returns 0 when n is 0.
+  if (n == 0)
+    return 0;
   uint64_t x = cromulent_next(state);
   __uint128_t m = (__uint128_t)x * n;
   uint64_t l = (uint64_t)m;
@@ -142,6 +145,9 @@ static void mul_u64(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo) {
 }
 
 uint64_t cromulent_range(cromulent_state *state, uint64_t n) {
+  // Generate a uniform random number in [0, n). Returns 0 when n is 0.
+  if (n == 0)
+    return 0;
   uint64_t x = cromulent_next(state);
   uint64_t hi, lo;
   mul_u64(x, n, &hi, &lo);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,22 +5,25 @@ add_executable(test_jump jump.c)
 add_executable(test_save save.c)
 add_executable(test_load load.c)
 add_executable(test_strong_next strong_next.c)
+add_executable(test_range range.c)
 
 # Link against the cromulent library
 target_link_libraries(test_jump cromulent)
 target_link_libraries(test_save cromulent)
 target_link_libraries(test_load cromulent)
 target_link_libraries(test_strong_next cromulent)
+target_link_libraries(test_range cromulent)
 
 # Add the tests to CTest
 add_test(NAME test_jump COMMAND test_jump)
 add_test(NAME test_save COMMAND test_save)
 add_test(NAME test_load COMMAND test_load)
 add_test(NAME test_strong_next COMMAND test_strong_next)
+add_test(NAME test_range COMMAND test_range)
 
 # Create a "run_all_unit_tests" target
 add_custom_target(run_all_unit_tests
     COMMAND ${CMAKE_CTEST_COMMAND} -V
-    DEPENDS test_jump test_save test_load test_strong_next
+    DEPENDS test_jump test_save test_load test_strong_next test_range
     COMMENT "Running all unit tests"
 )

--- a/tests/unit/range.c
+++ b/tests/unit/range.c
@@ -1,0 +1,23 @@
+// tests/unit/range.c
+//
+// Unit test for the cromulent_range functionality when n == 0
+
+#include "cromulent.h"
+#include <stdio.h>
+
+int main() {
+    printf("Testing cromulent_range with n=0... ");
+
+    cromulent_state st;
+    cromulent_init(&st, 0x123456789ABCDEF0ULL);
+
+    uint64_t val = cromulent_range(&st, 0);
+    if (val != 0) {
+        fprintf(stderr, "Expected 0, got %llu\n", (unsigned long long)val);
+        return 1;
+    }
+
+    printf("OK\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Return 0 from `cromulent_range` when the upper bound is 0 in both implementations
- Cover zero bound case with a new `test_range`

## Testing
- `cmake -S . -B build`
- `cmake --build build --target run_all_unit_tests`


------
https://chatgpt.com/codex/tasks/task_e_6893c45b153083289b6b534eefecf60f