### PR TITLE
Fix pcg64pp rotation to 64-bit width

### DIFF
--- a/src/reference/pcg64.c
+++ b/src/reference/pcg64.c
@@ -16,5 +16,5 @@ uint64_t pcg64pp(void) {
   pcg_state = oldstate * 6364136223846793005ULL + pcg_inc;
   uint64_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
   uint64_t rot = oldstate >> 59u;
-  return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+  return (xorshifted >> rot) | (xorshifted << ((-rot) & 63));
 }


### PR DESCRIPTION
## Summary
- expand pcg64pp rotation mask to 63 for full 64-bit coverage

## Testing
- `cmake ..`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893c4492d748328aed91e47251810e5