### PR TITLE
Limit AVX2 compile flag to SIMD source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,11 @@ check_c_compiler_flag(-mavx2 HAS_AVX2)
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" AND HAS_AVX2)
     list(APPEND CROMULENT_SRCS src/simd/cromulent_avx2.c)
+    set_source_files_properties(src/simd/cromulent_avx2.c PROPERTIES COMPILE_OPTIONS "-mavx2")
 endif ()
 
 add_library(cromulent STATIC ${CROMULENT_SRCS})
 target_include_directories(cromulent PUBLIC ${PROJECT_SOURCE_DIR}/include)
-
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" AND HAS_AVX2)
-    target_compile_options(cromulent PRIVATE -mavx2)
-endif ()
 
 add_executable(bench_micro apps/bench_micro.c)
 target_link_libraries(bench_micro cromulent)

--- a/include/cromulent.h
+++ b/include/cromulent.h
@@ -32,6 +32,9 @@ typedef struct {
   __m256i s0, s1;
 } cromulent_avx2_state;
 
+// Callers must only dispatch to the AVX2 entry points when the CPU reports
+// support for the instruction set; the scalar implementations remain the
+// baseline fall-back.
 void cromulent_avx2_init(cromulent_avx2_state *state, uint64_t seed);
 __m256i cromulent_avx2_next(cromulent_avx2_state *state);
 #endif


### PR DESCRIPTION
## Summary
- apply the AVX2-specific compile option only to cromulent_avx2.c and keep the rest of the library targeting the baseline CPU
- document in the public header that the AVX2 entry points require runtime dispatch based on CPU support

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68df3a2cc9288328832a13a4d0507569