### PR TITLE
Fix bench_micro dummy printf format

### DIFF
--- a/apps/bench_micro.c
+++ b/apps/bench_micro.c
@@ -30,8 +30,8 @@ void benchmark(const char *name, void (*init)(uint64_t), uint64_t (*next)(void),
   clock_gettime(CLOCK_MONOTONIC, &end);
   double time_ns =
       (end.tv_sec - start.tv_sec) * 1e9 + (end.tv_nsec - start.tv_nsec);
-  printf("%-15s: %.2f ns/sample, dummy=%lu\n", name, time_ns / NUM_SAMPLES,
-         dummy);
+  printf("%-15s: %.2f ns/sample, dummy=%" PRIu64 "\n", name,
+         time_ns / NUM_SAMPLES, dummy);
 }
 
 int main(void) {


### PR DESCRIPTION
## Summary
- use PRIu64 when printing the benchmark dummy accumulator so it works across LP64 and LLP64 ABIs

## Testing
- cmake -S . -B build
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68df3a39a55c83289512b7f2a0c9e724