### PR TITLE
Fix load_le64 endianness and reinforce load test

### DIFF
--- a/src/scalar/cromulent_scalar.c
+++ b/src/scalar/cromulent_scalar.c
@@ -11,9 +11,8 @@ static void store_le64(uint8_t *out, uint64_t x) {
 
 static uint64_t load_le64(const uint8_t *in) {
   uint64_t x = 0;
-  for (int i = 7; i >= 0; i--) {
-    x <<= 8;
-    x |= in[i];
+  for (int i = 0; i < 8; i++) {
+    x |= ((uint64_t)in[i]) << (8 * i);
   }
   return x;
 }

--- a/tests/unit/load.c
+++ b/tests/unit/load.c
@@ -24,14 +24,24 @@ int test_load_basic() {
     
     cromulent_state st_original, st_loaded;
     cromulent_init(&st_original, 0xDEADBEEFCAFEBABEULL);
-    
+
     // Save the original state
     uint8_t buffer[16];
     cromulent_save(&st_original, buffer);
-    
+
+    // Verify the serialized bytes are little-endian representations
+    uint8_t expected[16];
+    for (int i = 0; i < 8; i++) {
+        expected[i] = (uint8_t)(st_original.s0 >> (8 * i));
+        expected[8 + i] = (uint8_t)(st_original.s1 >> (8 * i));
+    }
+
+    CHECK(memcmp(buffer, expected, sizeof(expected)) == 0,
+          "Serialized state should use little-endian layout");
+
     // Initialize loaded state with a different seed
     cromulent_init(&st_loaded, 0x0000000000000000ULL);
-    
+
     // Load the saved state
     cromulent_load(&st_loaded, buffer);
     


### PR DESCRIPTION
## Summary
- adjust load_le64 to rebuild 64-bit words by accumulating each byte in little-endian order
- extend the basic load unit test to verify serialized bytes and reloaded state words

## Testing
- ctest --test-dir build/tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68df3a0ec58483288a163d45e5e9df31