### PR TITLE
Fix fallback 64x64 multiplication and add regression coverage

### DIFF
--- a/include/internal.h
+++ b/include/internal.h
@@ -72,4 +72,35 @@ static inline uint64_t mix_fast(uint64_t x) {
   return x;
 }
 
+static inline void cromulent_mul_u64_fallback(uint64_t a, uint64_t b,
+                                              uint64_t *hi, uint64_t *lo) {
+  const uint64_t mask32 = 0xffffffffULL;
+  const uint64_t a_lo = a & mask32;
+  const uint64_t a_hi = a >> 32;
+  const uint64_t b_lo = b & mask32;
+  const uint64_t b_hi = b >> 32;
+
+  const uint64_t p0 = a_lo * b_lo;
+  const uint64_t p1 = a_lo * b_hi;
+  const uint64_t p2 = a_hi * b_lo;
+  const uint64_t p3 = a_hi * b_hi;
+
+  uint64_t low = p0;
+  uint64_t carry = 0;
+
+  const uint64_t cross1 = (p1 & mask32) << 32;
+  low += cross1;
+  if (low < cross1)
+    carry++;
+
+  const uint64_t cross2 = (p2 & mask32) << 32;
+  uint64_t new_low = low + cross2;
+  if (new_low < cross2)
+    carry++;
+
+  low = new_low;
+  *lo = low;
+  *hi = p3 + (p1 >> 32) + (p2 >> 32) + carry;
+}
+
 #endif // CROMULENT_INTERNAL

--- a/src/scalar/cromulent_scalar.c
+++ b/src/scalar/cromulent_scalar.c
@@ -129,19 +129,7 @@ uint64_t cromulent_range(cromulent_state *state, uint64_t n) {
 }
 #else
 static void mul_u64(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo) {
-  uint64_t a_lo = a & 0xffffffffULL;
-  uint64_t a_hi = a >> 32;
-  uint64_t b_lo = b & 0xffffffffULL;
-  uint64_t b_hi = b >> 32;
-
-  uint64_t p0 = a_lo * b_lo;
-  uint64_t p1 = a_lo * b_hi;
-  uint64_t p2 = a_hi * b_lo;
-  uint64_t p3 = a_hi * b_hi;
-
-  uint64_t mid = (p0 >> 32) + (uint32_t)p1 + (uint32_t)p2;
-  *hi = p3 + (mid >> 32) + (p1 >> 32) + (p2 >> 32);
-  *lo = (mid << 32) | (uint32_t)p0;
+  cromulent_mul_u64_fallback(a, b, hi, lo);
 }
 
 uint64_t cromulent_range(cromulent_state *state, uint64_t n) {

--- a/tests/unit/range.c
+++ b/tests/unit/range.c
@@ -3,7 +3,28 @@
 // Unit test for the cromulent_range functionality when n == 0
 
 #include "cromulent.h"
+#include <inttypes.h>
 #include <stdio.h>
+
+struct mul_case {
+    uint64_t a;
+    uint64_t b;
+    uint64_t expected_hi;
+    uint64_t expected_lo;
+};
+
+static const struct mul_case kMulCases[] = {
+    {0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL},
+    {0x0000000000000001ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL},
+    {0xffffffffffffffffULL, 0xffffffffffffffffULL, 0xfffffffffffffffeULL, 0x0000000000000001ULL},
+    {0x0000000100000001ULL, 0x0000000200000003ULL, 0x0000000000000002ULL, 0x0000000500000003ULL},
+    {0x0123456789abcdefULL, 0xfedcba9876543210ULL, 0x0121fa00ad77d742ULL, 0x2236d88fe5618cf0ULL},
+    {0x8000000000000000ULL, 0x0000000000000002ULL, 0x0000000000000001ULL, 0x0000000000000000ULL},
+    {0x00000000ffffffffULL, 0xffffffff00000000ULL, 0x00000000fffffffeULL, 0x0000000100000000ULL},
+    {0xaaaaaaaa55555555ULL, 0x0f0f0f0ff0f0f0f0ULL, 0x0a0a0a0a9b9b9b9aULL, 0xaaaaaaaaafafafb0ULL},
+    {0xdeadbeefcafebabeULL, 0x1234567890abcdefULL, 0x0fd5bdeee268600eULL, 0x773285ae1c447d62ULL},
+    {0x0000000000000001ULL, 0xffffffffffffffffULL, 0x0000000000000000ULL, 0xffffffffffffffffULL},
+};
 
 int main() {
     printf("Testing cromulent_range with n=0... ");
@@ -18,6 +39,33 @@ int main() {
     }
 
     printf("OK\n");
+
+    printf("Testing 64x64->128 fallback multiplication parity... ");
+    for (size_t i = 0; i < sizeof(kMulCases) / sizeof(kMulCases[0]); ++i) {
+        uint64_t hi_fallback = 0;
+        uint64_t lo_fallback = 0;
+        cromulent_mul_u64_fallback(kMulCases[i].a, kMulCases[i].b, &hi_fallback, &lo_fallback);
+
+#ifdef __SIZEOF_INT128__
+        __uint128_t product = (__uint128_t)kMulCases[i].a * (__uint128_t)kMulCases[i].b;
+        uint64_t hi_native = (uint64_t)(product >> 64);
+        uint64_t lo_native = (uint64_t)product;
+#else
+        uint64_t hi_native = kMulCases[i].expected_hi;
+        uint64_t lo_native = kMulCases[i].expected_lo;
+#endif
+
+        if (hi_fallback != hi_native || lo_fallback != lo_native) {
+            fprintf(stderr,
+                    "Mismatch for case %zu: A=0x%016" PRIx64 ", B=0x%016" PRIx64
+                    ", fallback=(0x%016" PRIx64 ", 0x%016" PRIx64 ") expected=(0x%016" PRIx64
+                    ", 0x%016" PRIx64 ")\n",
+                    i, kMulCases[i].a, kMulCases[i].b, hi_fallback, lo_fallback, hi_native, lo_native);
+            return 1;
+        }
+    }
+    printf("OK\n");
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add a shared helper implementing the 64×64→128 fallback multiply with explicit carry propagation
- reuse the helper inside the scalar fallback path and add regression cases that compare it with the __uint128_t result

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68df3a1440e88328b1f1303673e11cba