### PR TITLE
Clarify jump operation limitations and refactor mixing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cromulent PRNG is a portable C library providing a high-quality random number ge
   - Basic operations: initialization, next value
   - Utilities: uniform doubles/floats, bounded ranges
   - State management: save/load for reproducibility
-  - Jump-ahead functionality for stream separation
+  - Jump-based state decorrelation (best-effort sub-stream separation; see caveat below)
 
 - Built-in benchmarking and testing tools
 - Small footprint with minimal dependencies
@@ -161,4 +161,6 @@ The generator uses a carefully designed output mixing function to improve statis
 
 ### Jump Operations
 
-The library supports jump-ahead operations, allowing you to efficiently advance the state by 2^64 steps. This is useful for creating independent, non-overlapping streams for parallel applications.
+The library provides a `cromulent_jump` operation that cheaply advances the state to a distinct-looking sub-stream.
+
+> **Note:** This is *not* a proven 2^64 skip-ahead. The polynomial-style jump used here is only exact for GF(2)-linear generators (e.g. xoshiro); the cromulent recurrence is nonlinear, so `cromulent_jump` performs a deterministic state decorrelation rather than a verified jump. It does **not** guarantee non-overlapping streams and should not be relied upon for parallel-stream independence until a real skip-ahead for this recurrence is implemented.

--- a/include/internal.h
+++ b/include/internal.h
@@ -34,12 +34,13 @@ static inline __m256i mullo_epi64_avx2(__m256i a, __m256i b) {
   return _mm256_add_epi64(albl, cross);
 }
 
-static inline __m256i mix_avx2(__m256i x) {
-  x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
-  x = mullo_epi64_avx2(x, _mm256_set1_epi64x(0xff51afd7ed558ccdULL));
-  x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
-  x = mullo_epi64_avx2(x, _mm256_set1_epi64x(0xc4ceb9fe1a85ec53ULL));
-  x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 33));
+// Vectorized counterpart of the scalar mix_fast(): a single-multiply finalizer
+// using MH3. Must stay in lock-step with mix_fast() so that cromulent_avx2_next
+// reproduces the scalar cromulent_next stream lane-for-lane.
+static inline __m256i mix_fast_avx2(__m256i x) {
+  x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 32));
+  x = mullo_epi64_avx2(x, _mm256_set1_epi64x(MH3));
+  x = _mm256_xor_si256(x, _mm256_srli_epi64(x, 32));
   return x;
 }
 #endif

--- a/src/scalar/cromulent_scalar.c
+++ b/src/scalar/cromulent_scalar.c
@@ -87,8 +87,19 @@ float cromulent_float(cromulent_state *state) {
 }
 
 void cromulent_jump(cromulent_state *state) {
-  // Matrix exponentiation for jumping
-  // These constants represent [M^(2^64)] where M is the state transition matrix
+  // WARNING: This is NOT a proven 2^64 skip-ahead.
+  //
+  // The classic xoshiro/xorshift "jump polynomial" (advance one step per bit,
+  // XOR-accumulate the state where a polynomial bit is set) only yields a
+  // correct jump-ahead when the state transition is linear over GF(2). The
+  // cromulent recurrence is nonlinear (integer multiply + add in
+  // cromulent_next), so no such GF(2) matrix M exists and this procedure does
+  // NOT land 2^64 steps ahead. What it does provide is a deterministic,
+  // seed-dependent decorrelation of the state: it advances 128 steps and folds
+  // in a fixed subset of the visited states. It is suitable for cheaply
+  // deriving a distinct-looking sub-stream, but it does not guarantee that
+  // sub-streams are non-overlapping. Do not rely on it for parallel-stream
+  // independence until a real skip-ahead for this recurrence is implemented.
   const uint64_t jump_a[2] = {SC1, SC2};
 
   uint64_t s0 = 0;

--- a/src/simd/cromulent_avx2.c
+++ b/src/simd/cromulent_avx2.c
@@ -23,14 +23,12 @@ __m256i cromulent_avx2_next(cromulent_avx2_state *state) {
   __m256i s1 = state->s1;
 
   state->s0 =
-      _mm256_add_epi64(mullo_epi64_avx2(s0, _mm256_set1_epi64x(0xd1342543de82ef95ULL)),
-                       s1);
-  state->s1 = _mm256_add_epi64(rotl_avx2(s1, 31), mix_avx2(s0));
+      _mm256_add_epi64(mullo_epi64_avx2(s0, _mm256_set1_epi64x(C6)), s1);
+  state->s1 = _mm256_add_epi64(rotl_avx2(s1, 31), mix_fast_avx2(s0));
 
   __m256i result = _mm256_add_epi64(s0, rotl_avx2(s1, 11));
   result = _mm256_xor_si256(result, _mm256_srli_epi64(result, 27));
-  result =
-      mullo_epi64_avx2(result, _mm256_set1_epi64x(0x94d049bb133111ebULL));
+  result = mullo_epi64_avx2(result, _mm256_set1_epi64x(C3));
   result = _mm256_xor_si256(result, _mm256_srli_epi64(result, 27));
 
   return result;


### PR DESCRIPTION
## Summary
This PR corrects misleading documentation about the `cromulent_jump` operation and refactors the mixing functions for consistency and clarity. The jump operation does not provide a proven 2^64 skip-ahead as previously claimed; it instead provides deterministic state decorrelation suitable for cheap sub-stream derivation.

## Key Changes

- **Jump operation documentation**: Added comprehensive warnings in `cromulent_jump()` explaining that the polynomial-style jump is only mathematically exact for GF(2)-linear generators. Since cromulent uses nonlinear operations (integer multiply + add), the jump does not guarantee non-overlapping streams and should not be relied upon for parallel-stream independence.

- **Mixing function refactoring**: 
  - Renamed `mix_avx2()` to `mix_fast_avx2()` to clarify it's the vectorized counterpart of `mix_fast()`
  - Simplified the AVX2 mixing function from a triple-multiply finalizer to a single-multiply MH3-based finalizer to match the scalar `mix_fast()` implementation
  - Updated magic constants to use named macros (`C6`, `C3`, `MH3`) for maintainability and consistency across scalar and SIMD code paths

- **README updates**: Revised documentation to accurately describe jump operations as "best-effort sub-stream separation" with explicit caveats about the lack of proven skip-ahead guarantees.

## Implementation Details

The mixing function changes ensure that `cromulent_avx2_next()` reproduces the scalar `cromulent_next()` stream lane-for-lane, improving code maintainability and reducing the risk of subtle divergence between scalar and vectorized implementations.

https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6