### PR TITLE
Add JavaScript port

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,0 +1,22 @@
+name: JavaScript
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/javascript/**', '.github/workflows/javascript.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/javascript/**', '.github/workflows/javascript.yml' ]
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Test
+        working-directory: bindings/javascript
+        run: node --test

--- a/bindings/javascript/.gitignore
+++ b/bindings/javascript/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bindings/javascript/README.md
+++ b/bindings/javascript/README.md
@@ -1,0 +1,21 @@
+# Cromulent PRNG — JavaScript
+
+A dependency-free, BigInt-based ES-module port of the scalar Cromulent
+generator. `Engine` reproduces the C reference stream (`cromulent_init` /
+`cromulent_next`) bit-for-bit; `StrongEngine` mirrors the heavier
+`cromulent_strong` variant.
+
+```js
+import { Engine } from "./cromulent.mjs";
+
+const rng = new Engine(0x0123456789abcdefn);
+const x = rng.nextU64();     // BigInt
+const d = rng.nextDouble();  // [0, 1)
+const r = rng.bounded(6n);   // unbiased [0n, 6n)
+```
+
+## Test
+
+```bash
+node --test
+```

--- a/bindings/javascript/cromulent.mjs
+++ b/bindings/javascript/cromulent.mjs
@@ -1,0 +1,148 @@
+// The Cromulent PRNG — a JavaScript port of the scalar reference generator.
+//
+// `Engine` produces the identical 64-bit stream as the C reference
+// implementation (cromulent_init / cromulent_next) for any given seed.
+// `StrongEngine` mirrors the heavier cromulent_strong variant.
+//
+// JavaScript numbers cannot represent 64-bit integers exactly, so the state and
+// all arithmetic use BigInt, masked back to 64 bits with `MASK` to reproduce
+// the wrapping behavior of the C generator.
+
+const MASK = (1n << 64n) - 1n;
+
+const C1 = 0x9e3779b97f4a7c15n;
+const C2 = 0xbf58476d1ce4e5b9n;
+const C3 = 0x94d049bb133111ebn;
+const C6 = 0xd1342543de82ef95n;
+const MH3 = 0xd6e8feb86659fd93n;
+
+/** Default seed, shared with the C library. */
+export const DEFAULT_SEED = 0x853c49e6748fea9bn;
+
+function rotl(x, k) {
+  return ((x << k) | (x >> (64n - k))) & MASK;
+}
+
+function mixFast(x) {
+  x ^= x >> 32n;
+  x = (x * MH3) & MASK;
+  x ^= x >> 32n;
+  return x;
+}
+
+// SplitMix64-style seed expansion, matching cromulent_init.
+function seedExpand(seed) {
+  let z = BigInt.asUintN(64, seed);
+  const out = [];
+  for (let i = 0; i < 2; i++) {
+    z = (z + C1) & MASK;
+    z = ((z ^ (z >> 30n)) * C2) & MASK;
+    z = ((z ^ (z >> 27n)) * C3) & MASK;
+    out.push(z ^ (z >> 31n));
+  }
+  return out;
+}
+
+/** The primary Cromulent generator. */
+export class Engine {
+  #s0;
+  #s1;
+
+  constructor(seed = DEFAULT_SEED) {
+    [this.#s0, this.#s1] = seedExpand(BigInt(seed));
+  }
+
+  /** Advance the state and return the next 64-bit output as a BigInt. */
+  nextU64() {
+    const s0 = this.#s0;
+    const s1 = this.#s1;
+
+    this.#s0 = (s0 * C6 + s1) & MASK;
+    this.#s1 = (rotl(s1, 31n) + mixFast(s0)) & MASK;
+
+    let result = (s0 + rotl(s1, 11n)) & MASK;
+    result ^= result >> 27n;
+    result = (result * C3) & MASK;
+    result ^= result >> 27n;
+    return result;
+  }
+
+  /** Uniform Number in [0, 1) using the top 53 bits. */
+  nextDouble() {
+    return Number(this.nextU64() >> 11n) * 2 ** -53;
+  }
+
+  /** Uniform Number in [0, 1) using the top 24 bits (single precision). */
+  nextFloat() {
+    return Number(this.nextU64() >> 40n) * 2 ** -24;
+  }
+
+  /**
+   * Unbiased uniform integer in [0, n) via Lemire's method.
+   * Returns 0n when n is 0n.
+   * @param {bigint} n
+   */
+  bounded(n) {
+    n = BigInt(n);
+    if (n === 0n) return 0n;
+    let m = this.nextU64() * n;
+    let low = m & MASK;
+    if (low < n) {
+      const threshold = ((MASK + 1n - n) % n);
+      while (low < threshold) {
+        m = this.nextU64() * n;
+        low = m & MASK;
+      }
+    }
+    return m >> 64n;
+  }
+
+  /** Advance the stream by z steps, discarding the output. */
+  discard(z) {
+    for (let i = 0n, n = BigInt(z); i < n; i++) this.nextU64();
+  }
+
+  [Symbol.iterator]() {
+    return { next: () => ({ value: this.nextU64(), done: false }) };
+  }
+}
+
+/** The heavier "strong" Cromulent variant. */
+export class StrongEngine {
+  #a;
+  #b;
+
+  constructor(seed = DEFAULT_SEED) {
+    [this.#a, this.#b] = seedExpand(BigInt(seed));
+  }
+
+  /** Advance the state and return the next 64-bit output as a BigInt. */
+  nextU64() {
+    let a = this.#a;
+    let b = this.#b;
+
+    b = (b + rotl(a, 13n)) & MASK;
+    a = (rotl(a, 29n) * C1 + b) & MASK;
+
+    b = rotl(b, 17n) ^ a;
+    a = (a + rotl((b * C2) & MASK, 31n)) & MASK;
+
+    b = (b + rotl(a, 23n)) & MASK;
+    a = rotl(a ^ b, 52n);
+
+    const output = (a + rotl(b, 41n)) & MASK;
+
+    this.#a = (a + C1) & MASK;
+    this.#b = b ^ (a >> 17n);
+
+    return mixFast(output);
+  }
+
+  discard(z) {
+    for (let i = 0n, n = BigInt(z); i < n; i++) this.nextU64();
+  }
+
+  [Symbol.iterator]() {
+    return { next: () => ({ value: this.nextU64(), done: false }) };
+  }
+}

--- a/bindings/javascript/cromulent.test.mjs
+++ b/bindings/javascript/cromulent.test.mjs
@@ -1,0 +1,69 @@
+// Tests for the JavaScript Cromulent port.
+// Run with: node --test   (Node 18+)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Engine, StrongEngine } from "./cromulent.mjs";
+
+const ENGINE_REF = [
+  0x8b0849848b39737dn,
+  0x829ecfb661e3a84dn,
+  0x6cfb2afb89b5dc83n,
+  0x8ad5c0d490669f95n,
+  0x8d4459e6318f2474n,
+  0xa0b907b845990f61n,
+  0x2143675f2f4ff1ecn,
+  0x38fff6f9c33c4f8fn,
+];
+
+const STRONG_REF = [
+  0xa1e9fb73cc5c77fan,
+  0xd8bc61a96accc72en,
+  0x3f98dad0bcb1c8f3n,
+  0xb179513c44fe1f0an,
+  0x413b884be5b9955fn,
+  0x4b682d94916239a1n,
+  0xe7b93a4600d77791n,
+  0x6a54f95b111a3555n,
+];
+
+test("matches C reference", () => {
+  const e = new Engine(0x0123456789abcdefn);
+  for (const want of ENGINE_REF) assert.equal(e.nextU64(), want);
+});
+
+test("strong matches C reference", () => {
+  const e = new StrongEngine(0x0123456789abcdefn);
+  for (const want of STRONG_REF) assert.equal(e.nextU64(), want);
+});
+
+test("outputs are 64-bit", () => {
+  const e = new Engine(1n);
+  for (let i = 0; i < 1000; i++) {
+    const v = e.nextU64();
+    assert.ok(v >= 0n && v < 1n << 64n);
+  }
+});
+
+test("nextDouble in range", () => {
+  const e = new Engine(42n);
+  assert.ok(Math.abs(e.nextDouble() - 0.42990649088115307) < 1e-15);
+  for (let i = 0; i < 10000; i++) {
+    const d = e.nextDouble();
+    assert.ok(d >= 0 && d < 1);
+  }
+});
+
+test("bounded range", () => {
+  const e = new Engine(99n);
+  assert.equal(e.bounded(0n), 0n);
+  for (let i = 0; i < 10000; i++) assert.ok(e.bounded(7n) < 7n);
+});
+
+test("discard equivalence", () => {
+  const a = new Engine(555n);
+  const b = new Engine(555n);
+  a.discard(50);
+  for (let i = 0; i < 50; i++) b.nextU64();
+  for (let i = 0; i < 100; i++) assert.equal(a.nextU64(), b.nextU64());
+});

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cromulent-prng",
+  "version": "0.1.0",
+  "description": "The Cromulent PRNG (JavaScript port of the scalar reference generator)",
+  "type": "module",
+  "main": "cromulent.mjs",
+  "exports": "./cromulent.mjs",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seanwevans/Cromulent-PRNG.git"
+  }
+}


### PR DESCRIPTION
## Summary

A dependency-free, BigInt-based ES-module port of the scalar Cromulent generator under `bindings/javascript/`.

- `Engine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
- BigInt arithmetic masked to 64 bits reproduces the wrapping behavior of the C generator. Provides `nextDouble()`/`nextFloat()`, `bounded(n)` (unbiased, Lemire's method), `discard`, and the iterator protocol. Uses private class fields for state encapsulation.

## Verification
`node --test` — self-tests against shared reference vectors, plus 64-bit-range, double-range, bounded, and discard-equivalence checks. Passes locally on Node 22.

Self-contained (own `bindings/javascript/` package + JavaScript CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_