### PR TITLE
Add Java port

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,26 @@
+name: Java
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/java/**', '.github/workflows/java.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/java/**', '.github/workflows/java.yml' ]
+
+jobs:
+  test:
+    name: javac + run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Compile
+        working-directory: bindings/java
+        run: javac -d out $(find src -name '*.java')
+      - name: Test
+        working-directory: bindings/java
+        run: java -cp out com.cromulent.CromulentTest

--- a/bindings/java/.gitignore
+++ b/bindings/java/.gitignore
@@ -1,0 +1,2 @@
+out/
+*.class

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,0 +1,30 @@
+# Cromulent PRNG — Java
+
+A dependency-free Java port of the scalar Cromulent generator.
+`CromulentEngine` implements `java.util.random.RandomGenerator`, so the standard
+helpers (`nextInt(bound)`, `nextDouble()`, `ints()`/`longs()` streams, …) work
+out of the box — and `RandomGenerator`'s default `nextDouble()` is
+`(nextLong() >>> 11) * 0x1.0p-53`, matching `cromulent_double` exactly.
+
+`CromulentEngine` reproduces the C reference stream (`cromulent_init` /
+`cromulent_next`) bit-for-bit; `StrongEngine` mirrors the heavier
+`cromulent_strong` variant.
+
+```java
+import com.cromulent.CromulentEngine;
+
+var rng = new CromulentEngine(0x0123456789ABCDEFL);
+long x = rng.nextLong();
+int roll = rng.nextInt(6);      // [0, 6)
+double d = rng.nextDouble();    // [0, 1)
+long r = rng.bounded(6);        // unbiased [0, 6), unsigned
+```
+
+## Test
+
+No build tool required — compile the sources and run the self-test:
+
+```bash
+javac -d out $(find src -name '*.java')
+java -cp out com.cromulent.CromulentTest
+```

--- a/bindings/java/src/main/java/com/cromulent/CromulentEngine.java
+++ b/bindings/java/src/main/java/com/cromulent/CromulentEngine.java
@@ -1,0 +1,106 @@
+package com.cromulent;
+
+import java.util.random.RandomGenerator;
+
+/**
+ * The Cromulent PRNG — a Java port of the scalar reference generator.
+ *
+ * <p>This engine produces the identical 64-bit stream as the C reference
+ * implementation ({@code cromulent_init} / {@code cromulent_next}) for any given
+ * seed. It implements {@link RandomGenerator}, so the standard helpers
+ * ({@code nextInt(bound)}, {@code nextDouble()}, {@code ints()}/{@code longs()}
+ * streams, etc.) are available for free. Notably {@code RandomGenerator}'s
+ * default {@code nextDouble()} is {@code (nextLong() >>> 11) * 0x1.0p-53}, which
+ * matches {@code cromulent_double} exactly.
+ *
+ * <p>Java's {@code long} is 64-bit two's complement; addition, multiplication,
+ * and bitwise operations wrap identically to the unsigned C generator, so the
+ * only care needed is to use unsigned shifts ({@code >>>}) and unsigned
+ * comparisons where the value is interpreted as unsigned.
+ */
+public final class CromulentEngine implements RandomGenerator {
+
+    private static final long C1 = 0x9e3779b97f4a7c15L;
+    private static final long C3 = 0x94d049bb133111ebL;
+    private static final long C6 = 0xd1342543de82ef95L;
+    private static final long MH3 = 0xd6e8feb86659fd93L;
+
+    /** Default seed, shared with the C library. */
+    public static final long DEFAULT_SEED = 0x853c49e6748fea9bL;
+
+    private long s0;
+    private long s1;
+
+    /** Creates an engine seeded with {@link #DEFAULT_SEED}. */
+    public CromulentEngine() {
+        this(DEFAULT_SEED);
+    }
+
+    /** Creates an engine seeded from a single 64-bit value. */
+    public CromulentEngine(long seed) {
+        long[] st = Seeding.expand(seed);
+        this.s0 = st[0];
+        this.s1 = st[1];
+    }
+
+    /** Advances the state and returns the next 64-bit output. */
+    @Override
+    public long nextLong() {
+        final long s0 = this.s0;
+        final long s1 = this.s1;
+
+        this.s0 = s0 * C6 + s1;
+        this.s1 = Long.rotateLeft(s1, 31) + Seeding.mixFast(s0);
+
+        long result = s0 + Long.rotateLeft(s1, 11);
+        result ^= result >>> 27;
+        result *= C3;
+        result ^= result >>> 27;
+        return result;
+    }
+
+    /**
+     * Unbiased uniform integer in {@code [0, n)} via Lemire's method, treating
+     * {@code n} as unsigned. Returns 0 when {@code n == 0}.
+     */
+    public long bounded(long n) {
+        if (n == 0) {
+            return 0;
+        }
+        long x = nextLong();
+        long low = x * n;
+        long hi = Seeding.unsignedMultiplyHigh(x, n);
+        if (Long.compareUnsigned(low, n) < 0) {
+            long threshold = Long.remainderUnsigned(-n, n);
+            while (Long.compareUnsigned(low, threshold) < 0) {
+                x = nextLong();
+                low = x * n;
+                hi = Seeding.unsignedMultiplyHigh(x, n);
+            }
+        }
+        return hi;
+    }
+
+    /** Advances the stream by {@code z} steps, discarding the output. */
+    public void discard(long z) {
+        for (long i = 0; i < z; i++) {
+            nextLong();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CromulentEngine other)) {
+            return false;
+        }
+        return s0 == other.s0 && s1 == other.s1;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(s0) * 31 + Long.hashCode(s1);
+    }
+}

--- a/bindings/java/src/main/java/com/cromulent/Seeding.java
+++ b/bindings/java/src/main/java/com/cromulent/Seeding.java
@@ -1,0 +1,53 @@
+package com.cromulent;
+
+/** Shared helpers for the Cromulent engines. */
+final class Seeding {
+
+    private static final long C1 = 0x9e3779b97f4a7c15L;
+    private static final long C2 = 0xbf58476d1ce4e5b9L;
+    private static final long C3 = 0x94d049bb133111ebL;
+    private static final long MH3 = 0xd6e8feb86659fd93L;
+
+    private Seeding() {
+    }
+
+    static long mixFast(long x) {
+        x ^= x >>> 32;
+        x *= MH3;
+        x ^= x >>> 32;
+        return x;
+    }
+
+    /** SplitMix64-style seed expansion, matching {@code cromulent_init}. */
+    static long[] expand(long seed) {
+        long z = seed;
+        long[] out = new long[2];
+        for (int i = 0; i < 2; i++) {
+            z += C1;
+            z = (z ^ (z >>> 30)) * C2;
+            z = (z ^ (z >>> 27)) * C3;
+            out[i] = z ^ (z >>> 31);
+        }
+        return out;
+    }
+
+    /**
+     * High 64 bits of the unsigned 128-bit product {@code a * b}. Implemented
+     * with 32-bit limbs so it works on any JDK (independent of
+     * {@code Math.unsignedMultiplyHigh}, which is JDK 18+).
+     */
+    static long unsignedMultiplyHigh(long a, long b) {
+        long aLo = a & 0xffffffffL;
+        long aHi = a >>> 32;
+        long bLo = b & 0xffffffffL;
+        long bHi = b >>> 32;
+
+        long lolo = aLo * bLo;
+        long hilo = aHi * bLo;
+        long lohi = aLo * bHi;
+        long hihi = aHi * bHi;
+
+        long carry = ((lolo >>> 32) + (hilo & 0xffffffffL) + (lohi & 0xffffffffL)) >>> 32;
+        return hihi + (hilo >>> 32) + (lohi >>> 32) + carry;
+    }
+}

--- a/bindings/java/src/main/java/com/cromulent/StrongEngine.java
+++ b/bindings/java/src/main/java/com/cromulent/StrongEngine.java
@@ -1,0 +1,74 @@
+package com.cromulent;
+
+import java.util.random.RandomGenerator;
+
+/**
+ * The heavier "strong" Cromulent variant. Mirrors {@code cromulent_strong_init}
+ * / {@code cromulent_strong_next} and implements {@link RandomGenerator}.
+ */
+public final class StrongEngine implements RandomGenerator {
+
+    private static final long C1 = 0x9e3779b97f4a7c15L;
+    private static final long C2 = 0xbf58476d1ce4e5b9L;
+
+    /** Default seed, shared with the C library. */
+    public static final long DEFAULT_SEED = 0x853c49e6748fea9bL;
+
+    private long a;
+    private long b;
+
+    public StrongEngine() {
+        this(DEFAULT_SEED);
+    }
+
+    public StrongEngine(long seed) {
+        long[] st = Seeding.expand(seed);
+        this.a = st[0];
+        this.b = st[1];
+    }
+
+    @Override
+    public long nextLong() {
+        long a = this.a;
+        long b = this.b;
+
+        b += Long.rotateLeft(a, 13);
+        a = Long.rotateLeft(a, 29) * C1 + b;
+
+        b = Long.rotateLeft(b, 17) ^ a;
+        a += Long.rotateLeft(b * C2, 31);
+
+        b += Long.rotateLeft(a, 23);
+        a = Long.rotateLeft(a ^ b, 52);
+
+        final long output = a + Long.rotateLeft(b, 41);
+
+        this.a = a + C1;
+        this.b = b ^ (a >>> 17);
+
+        return Seeding.mixFast(output);
+    }
+
+    /** Advances the stream by {@code z} steps, discarding the output. */
+    public void discard(long z) {
+        for (long i = 0; i < z; i++) {
+            nextLong();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StrongEngine other)) {
+            return false;
+        }
+        return a == other.a && b == other.b;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(a) * 31 + Long.hashCode(b);
+    }
+}

--- a/bindings/java/src/test/java/com/cromulent/CromulentTest.java
+++ b/bindings/java/src/test/java/com/cromulent/CromulentTest.java
@@ -1,0 +1,106 @@
+package com.cromulent;
+
+import java.util.random.RandomGenerator;
+
+/**
+ * Self-contained test runner (no external test framework) for the Java port.
+ * Verifies bit-for-bit parity with the C reference vectors and exercises the
+ * RandomGenerator integration. Exits non-zero on the first failure.
+ */
+public final class CromulentTest {
+
+    private static final long[] ENGINE_REF = {
+        0x8b0849848b39737dL, 0x829ecfb661e3a84dL, 0x6cfb2afb89b5dc83L,
+        0x8ad5c0d490669f95L, 0x8d4459e6318f2474L, 0xa0b907b845990f61L,
+        0x2143675f2f4ff1ecL, 0x38fff6f9c33c4f8fL,
+    };
+
+    private static final long[] STRONG_REF = {
+        0xa1e9fb73cc5c77faL, 0xd8bc61a96accc72eL, 0x3f98dad0bcb1c8f3L,
+        0xb179513c44fe1f0aL, 0x413b884be5b9955fL, 0x4b682d94916239a1L,
+        0xe7b93a4600d77791L, 0x6a54f95b111a3555L,
+    };
+
+    private static int failures = 0;
+
+    private static void check(boolean cond, String msg) {
+        if (!cond) {
+            System.err.println("FAIL: " + msg);
+            failures++;
+        }
+    }
+
+    private static void testMatchesReference() {
+        System.out.print("Testing engine matches C reference... ");
+        CromulentEngine e = new CromulentEngine(0x0123456789ABCDEFL);
+        for (int i = 0; i < ENGINE_REF.length; i++) {
+            check(e.nextLong() == ENGINE_REF[i], "engine output " + i);
+        }
+        System.out.println("OK");
+    }
+
+    private static void testStrongMatchesReference() {
+        System.out.print("Testing strong engine matches C reference... ");
+        StrongEngine e = new StrongEngine(0x0123456789ABCDEFL);
+        for (int i = 0; i < STRONG_REF.length; i++) {
+            check(e.nextLong() == STRONG_REF[i], "strong output " + i);
+        }
+        System.out.println("OK");
+    }
+
+    private static void testRandomGeneratorIntegration() {
+        System.out.print("Testing RandomGenerator integration... ");
+        RandomGenerator rng = new CromulentEngine(12345);
+
+        // Default nextDouble() is (nextLong() >>> 11) * 0x1.0p-53, matching C.
+        RandomGenerator d = new CromulentEngine(42);
+        check(Math.abs(d.nextDouble() - 0.42990649088115307) < 1e-15,
+              "nextDouble matches cromulent_double");
+
+        for (int i = 0; i < 10000; i++) {
+            int roll = rng.nextInt(6);
+            check(roll >= 0 && roll < 6, "nextInt(6) in range");
+            double v = rng.nextDouble();
+            check(v >= 0.0 && v < 1.0, "nextDouble in [0,1)");
+        }
+        System.out.println("OK");
+    }
+
+    private static void testBounded() {
+        System.out.print("Testing bounded()... ");
+        CromulentEngine e = new CromulentEngine(99);
+        check(e.bounded(0) == 0, "bounded(0) == 0");
+        for (int i = 0; i < 10000; i++) {
+            check(Long.compareUnsigned(e.bounded(7), 7) < 0, "bounded(7) < 7");
+        }
+        System.out.println("OK");
+    }
+
+    private static void testDiscardAndEquals() {
+        System.out.print("Testing discard/equals... ");
+        CromulentEngine a = new CromulentEngine(555);
+        CromulentEngine b = new CromulentEngine(555);
+        a.discard(50);
+        for (int i = 0; i < 50; i++) {
+            b.nextLong();
+        }
+        check(a.equals(b), "discard(n) equals n calls");
+        System.out.println("OK");
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Running Cromulent Java engine tests");
+        testMatchesReference();
+        testStrongMatchesReference();
+        testRandomGeneratorIntegration();
+        testBounded();
+        testDiscardAndEquals();
+
+        if (failures == 0) {
+            System.out.println("All Java engine tests passed successfully!");
+        } else {
+            System.out.println(failures + " check(s) failed!");
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A dependency-free Java port of the scalar Cromulent generator under `bindings/java/`.

- `CromulentEngine` implements **`java.util.random.RandomGenerator`** (JDK 17+), so the standard helpers — `nextInt(bound)`, `nextDouble()`, `ints()`/`longs()` streams — work out of the box. `RandomGenerator`'s default `nextDouble()` is `(nextLong() >>> 11) * 0x1.0p-53`, which matches `cromulent_double` exactly.
- Reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
- Provides `bounded(n)` (unbiased, Lemire's method, unsigned) and `discard`. The 128-bit-product high word is computed with 32-bit limbs so it works on any JDK (no dependence on `Math.unsignedMultiplyHigh`).

## Verification
Compile and run the self-test (no build tool required):

```bash
javac -d out $(find src -name '*.java')
java -cp out com.cromulent.CromulentTest
```

Self-tests against shared reference vectors, plus `RandomGenerator` integration, bounded, and discard-equivalence checks. Passes locally on Temurin 21.

Self-contained (own `bindings/java/` sources + Java CI workflow); does not modify the root build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_