### PR TITLE
Add Nim port

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -1,0 +1,22 @@
+name: Nim
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/nim/**', '.github/workflows/nim.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/nim/**', '.github/workflows/nim.yml' ]
+
+jobs:
+  test:
+    name: nim c -r
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: 'stable'
+      - name: Test
+        working-directory: bindings/nim
+        run: nim c -r --hints:off tests/test_cromulent.nim

--- a/bindings/nim/.gitignore
+++ b/bindings/nim/.gitignore
@@ -1,0 +1,3 @@
+nimcache/
+tests/test_cromulent
+*.exe

--- a/bindings/nim/README.md
+++ b/bindings/nim/README.md
@@ -1,0 +1,22 @@
+# Cromulent PRNG — Nim
+
+A dependency-free Nim port of the scalar Cromulent generator. `CromulentEngine`
+reproduces the C reference stream (`cromulent_init` / `cromulent_next`)
+bit-for-bit; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
+Nim's `uint64` wraps on overflow, matching the C generator.
+
+```nim
+import cromulent
+
+var rng = initEngine(0x0123456789ABCDEF'u64)
+discard rng.next        # 64-bit output
+echo rng.nextFloat      # [0, 1)
+echo rng.bounded(6'u64) # unbiased [0, 6)
+```
+
+## Test
+
+```bash
+nim c -r tests/test_cromulent.nim
+# or: nimble test
+```

--- a/bindings/nim/cromulent.nimble
+++ b/bindings/nim/cromulent.nimble
@@ -1,0 +1,12 @@
+# Package
+version       = "0.1.0"
+author        = "Cromulent PRNG contributors"
+description   = "The Cromulent PRNG (Nim port of the scalar reference generator)"
+license       = "MIT"
+srcDir        = "src"
+
+# Dependencies
+requires "nim >= 1.6.0"
+
+task test, "Run the self-test":
+  exec "nim c -r --hints:off tests/test_cromulent.nim"

--- a/bindings/nim/src/cromulent.nim
+++ b/bindings/nim/src/cromulent.nim
@@ -1,0 +1,121 @@
+## The Cromulent PRNG -- a Nim port of the scalar reference generator.
+##
+## `CromulentEngine` reproduces the identical 64-bit stream as the C reference
+## implementation (`cromulent_init` / `cromulent_next`) for any given seed;
+## `StrongEngine` mirrors the heavier `cromulent_strong` variant. Nim's
+## `uint64` wraps on overflow, matching the C generator exactly.
+
+import std/bitops
+
+const
+  C1 = 0x9e3779b97f4a7c15'u64
+  C2 = 0xbf58476d1ce4e5b9'u64
+  C3 = 0x94d049bb133111eb'u64
+  C6 = 0xd1342543de82ef95'u64
+  MH3 = 0xd6e8feb86659fd93'u64
+
+  ## Default seed, shared with the C library.
+  DefaultSeed* = 0x853c49e6748fea9b'u64
+
+type
+  CromulentEngine* = object
+    s0, s1: uint64
+  StrongEngine* = object
+    a, b: uint64
+
+func mixFast(x0: uint64): uint64 =
+  var x = x0
+  x = x xor (x shr 32)
+  x = x * MH3
+  x = x xor (x shr 32)
+  x
+
+## SplitMix64-style seed expansion, matching cromulent_init.
+func seedExpand(seed: uint64): (uint64, uint64) =
+  var z = seed
+  var outv: array[2, uint64]
+  for i in 0 ..< 2:
+    z = z + C1
+    z = (z xor (z shr 30)) * C2
+    z = (z xor (z shr 27)) * C3
+    outv[i] = z xor (z shr 31)
+  (outv[0], outv[1])
+
+## High 64 bits of the unsigned 128-bit product a*b (32-bit limbs).
+func umulHigh(a, b: uint64): uint64 =
+  let
+    aLo = a and 0xffffffff'u64
+    aHi = a shr 32
+    bLo = b and 0xffffffff'u64
+    bHi = b shr 32
+    lolo = aLo * bLo
+    hilo = aHi * bLo
+    lohi = aLo * bHi
+    hihi = aHi * bHi
+    carry = ((lolo shr 32) + (hilo and 0xffffffff'u64) + (lohi and 0xffffffff'u64)) shr 32
+  hihi + (hilo shr 32) + (lohi shr 32) + carry
+
+## Construct an engine seeded from a single 64-bit value.
+func initEngine*(seed: uint64 = DefaultSeed): CromulentEngine =
+  (result.s0, result.s1) = seedExpand(seed)
+
+## Advance the state and return the next 64-bit output.
+func next*(e: var CromulentEngine): uint64 =
+  let
+    s0 = e.s0
+    s1 = e.s1
+  e.s0 = s0 * C6 + s1
+  e.s1 = rotateLeftBits(s1, 31) + mixFast(s0)
+  var r = s0 + rotateLeftBits(s1, 11)
+  r = r xor (r shr 27)
+  r = r * C3
+  r = r xor (r shr 27)
+  r
+
+## Uniform float in [0, 1) using the top 53 bits.
+func nextFloat*(e: var CromulentEngine): float64 =
+  float64(e.next shr 11) * (1.0 / float64(1'u64 shl 53))
+
+## Unbiased uniform integer in [0, n) via Lemire's method. Returns 0 when n == 0.
+func bounded*(e: var CromulentEngine, n: uint64): uint64 =
+  if n == 0'u64:
+    return 0'u64
+  var
+    x = e.next
+    low = x * n
+    hi = umulHigh(x, n)
+  if low < n:
+    let threshold = (0'u64 - n) mod n
+    while low < threshold:
+      x = e.next
+      low = x * n
+      hi = umulHigh(x, n)
+  hi
+
+## Advance the stream by z steps, discarding the output.
+func skip*(e: var CromulentEngine, z: uint64) =
+  for _ in 0'u64 ..< z:
+    discard e.next
+
+## Construct a strong engine seeded from a single 64-bit value.
+func initStrongEngine*(seed: uint64 = DefaultSeed): StrongEngine =
+  (result.a, result.b) = seedExpand(seed)
+
+func next*(e: var StrongEngine): uint64 =
+  var
+    a = e.a
+    b = e.b
+  b = b + rotateLeftBits(a, 13)
+  a = rotateLeftBits(a, 29) * C1 + b
+  b = rotateLeftBits(b, 17) xor a
+  a = a + rotateLeftBits(b * C2, 31)
+  b = b + rotateLeftBits(a, 23)
+  a = rotateLeftBits(a xor b, 52)
+  let output = a + rotateLeftBits(b, 41)
+  e.a = a + C1
+  e.b = b xor (a shr 17)
+  mixFast(output)
+
+func skip*(e: var StrongEngine, z: uint64) =
+  for _ in 0'u64 ..< z:
+    discard e.next

--- a/bindings/nim/tests/test_cromulent.nim
+++ b/bindings/nim/tests/test_cromulent.nim
@@ -1,0 +1,67 @@
+## Self-contained test for the Nim Cromulent port. Verifies bit-for-bit parity
+## with the C reference vectors and basic range/skip behavior.
+
+import ../src/cromulent
+
+const
+  engineRef = [
+    0x8b0849848b39737d'u64, 0x829ecfb661e3a84d'u64, 0x6cfb2afb89b5dc83'u64,
+    0x8ad5c0d490669f95'u64, 0x8d4459e6318f2474'u64, 0xa0b907b845990f61'u64,
+    0x2143675f2f4ff1ec'u64, 0x38fff6f9c33c4f8f'u64]
+  strongRef = [
+    0xa1e9fb73cc5c77fa'u64, 0xd8bc61a96accc72e'u64, 0x3f98dad0bcb1c8f3'u64,
+    0xb179513c44fe1f0a'u64, 0x413b884be5b9955f'u64, 0x4b682d94916239a1'u64,
+    0xe7b93a4600d77791'u64, 0x6a54f95b111a3555'u64]
+
+var failures = 0
+
+proc check(cond: bool, msg: string) =
+  if not cond:
+    stderr.writeLine("FAIL: " & msg)
+    inc failures
+
+echo "Running Cromulent Nim engine tests"
+
+stdout.write "Testing engine matches C reference... "
+var e = initEngine(0x0123456789ABCDEF'u64)
+for i in 0 ..< engineRef.len:
+  check(e.next == engineRef[i], "engine output " & $i)
+echo "OK"
+
+stdout.write "Testing strong engine matches C reference... "
+var s = initStrongEngine(0x0123456789ABCDEF'u64)
+for i in 0 ..< strongRef.len:
+  check(s.next == strongRef[i], "strong output " & $i)
+echo "OK"
+
+stdout.write "Testing nextFloat range... "
+var d = initEngine(42'u64)
+check(abs(d.nextFloat - 0.42990649088115307) < 1e-15, "first double")
+for _ in 0 ..< 10000:
+  let v = d.nextFloat
+  check(v >= 0.0 and v < 1.0, "double in range")
+echo "OK"
+
+stdout.write "Testing bounded... "
+var b = initEngine(99'u64)
+check(b.bounded(0'u64) == 0'u64, "bounded(0)")
+for _ in 0 ..< 10000:
+  check(b.bounded(7'u64) < 7'u64, "bounded(7) < 7")
+echo "OK"
+
+stdout.write "Testing skip equivalence... "
+var a1 = initEngine(555'u64)
+var a2 = initEngine(555'u64)
+a1.skip(50'u64)
+for _ in 0 ..< 50:
+  discard a2.next
+for _ in 0 ..< 100:
+  check(a1.next == a2.next, "skip(n) == n calls")
+echo "OK"
+
+if failures == 0:
+  echo "All Nim engine tests passed successfully!"
+  quit(0)
+else:
+  echo $failures & " check(s) failed!"
+  quit(1)


### PR DESCRIPTION
## Summary

A dependency-free Nim port of the scalar Cromulent generator under `bindings/nim/`.

- `CromulentEngine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
- Native `uint64` (wraps on overflow), `std/bitops` `rotateLeftBits`, a 32-bit-limb high-multiply for the unbiased `bounded` (Lemire's method), plus `nextFloat` and `skip`.

## Verification
`nim c -r tests/test_cromulent.nim` (or `nimble test`) — self-tests against shared reference vectors plus float-range, bounded, and skip-equivalence. Passes locally on Nim 1.6.

Self-contained (own `bindings/nim/` package + Nim CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_