### PR TITLE
Add Haskell port

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,22 @@
+name: Haskell
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/haskell/**', '.github/workflows/haskell.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/haskell/**', '.github/workflows/haskell.yml' ]
+
+jobs:
+  test:
+    name: runghc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.4'
+      - name: Test
+        working-directory: bindings/haskell
+        run: runghc -isrc test/Spec.hs

--- a/bindings/haskell/.gitignore
+++ b/bindings/haskell/.gitignore
@@ -1,0 +1,3 @@
+*.hi
+*.o
+dist-newstyle/

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -1,0 +1,24 @@
+# Cromulent PRNG — Haskell
+
+A dependency-free Haskell port of the scalar Cromulent generator. The engines
+are pure: each step returns the output together with the next state.
+`Engine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`)
+bit-for-bit; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
+`Word64` arithmetic is modular, matching the C generator.
+
+```haskell
+import Cromulent
+
+let e0 = mkEngine 0x0123456789ABCDEF
+    (x, e1) = next e0          -- 64-bit output + next engine
+    (d, e2) = nextDouble e1    -- [0, 1)
+    (r, e3) = bounded 6 e2     -- unbiased [0, 6)
+```
+
+## Test
+
+Uses only `base`, so no build tool is needed:
+
+```bash
+runghc -isrc test/Spec.hs
+```

--- a/bindings/haskell/src/Cromulent.hs
+++ b/bindings/haskell/src/Cromulent.hs
@@ -1,0 +1,119 @@
+-- | The Cromulent PRNG — a Haskell port of the scalar reference generator.
+--
+-- 'Engine' reproduces the identical 64-bit stream as the C reference
+-- implementation (@cromulent_init@ / @cromulent_next@) for any given seed;
+-- 'StrongEngine' mirrors the heavier @cromulent_strong@ variant.
+--
+-- 'Word64' arithmetic is modular (wraps at 2^64), matching the C generator.
+-- The engines are pure: each step returns the output together with the next
+-- engine state.
+module Cromulent
+  ( Engine
+  , StrongEngine
+  , defaultSeed
+  , mkEngine
+  , next
+  , nextDouble
+  , bounded
+  , discard
+  , mkStrongEngine
+  , strongNext
+  , strongDiscard
+  ) where
+
+import Data.Bits (rotateL, shiftR, xor)
+import Data.Word (Word64)
+
+c1, c2, c3, c6, mh3 :: Word64
+c1 = 0x9e3779b97f4a7c15
+c2 = 0xbf58476d1ce4e5b9
+c3 = 0x94d049bb133111eb
+c6 = 0xd1342543de82ef95
+mh3 = 0xd6e8feb86659fd93
+
+-- | Default seed, shared with the C library.
+defaultSeed :: Word64
+defaultSeed = 0x853c49e6748fea9b
+
+mixFast :: Word64 -> Word64
+mixFast x0 = x2 `xor` (x2 `shiftR` 32)
+  where
+    x1 = x0 `xor` (x0 `shiftR` 32)
+    x2 = x1 * mh3
+
+-- | SplitMix64-style seed expansion, matching cromulent_init.
+seedExpand :: Word64 -> (Word64, Word64)
+seedExpand seed = (v0, v1)
+  where
+    step z0 = let z1 = z0 + c1
+                  z2 = (z1 `xor` (z1 `shiftR` 30)) * c2
+                  z3 = (z2 `xor` (z2 `shiftR` 27)) * c3
+              in (z3 `xor` (z3 `shiftR` 31), z3)
+    (v0, za) = step seed
+    (v1, _) = step za
+
+-- | The primary Cromulent engine.
+data Engine = Engine !Word64 !Word64
+  deriving (Eq, Show)
+
+-- | Construct an engine seeded from a single 64-bit value.
+mkEngine :: Word64 -> Engine
+mkEngine seed = let (s0, s1) = seedExpand seed in Engine s0 s1
+
+-- | Advance the state; return the output and the next engine.
+next :: Engine -> (Word64, Engine)
+next (Engine s0 s1) = (result, Engine s0' s1')
+  where
+    s0' = s0 * c6 + s1
+    s1' = rotateL s1 31 + mixFast s0
+    r0 = s0 + rotateL s1 11
+    r1 = r0 `xor` (r0 `shiftR` 27)
+    r2 = r1 * c3
+    result = r2 `xor` (r2 `shiftR` 27)
+
+-- | Uniform Double in [0, 1) using the top 53 bits.
+nextDouble :: Engine -> (Double, Engine)
+nextDouble e = (fromIntegral (x `shiftR` 11) / 9007199254740992, e')
+  where (x, e') = next e
+
+-- | Unbiased uniform integer in [0, n) via Lemire's method. Returns 0 when n == 0.
+bounded :: Word64 -> Engine -> (Word64, Engine)
+bounded n e0
+  | n == 0 = (0, e0)
+  | otherwise = go (next e0)
+  where
+    threshold = fromInteger ((2 ^ (64 :: Int) - toInteger n) `mod` toInteger n) :: Word64
+    go (x, e) =
+      let m = toInteger x * toInteger n
+          low = fromInteger m :: Word64
+          hi = fromInteger (m `div` (2 ^ (64 :: Int))) :: Word64
+      in if low < threshold then go (next e) else (hi, e)
+
+-- | Advance the stream by k steps, discarding the output.
+discard :: Word64 -> Engine -> Engine
+discard 0 e = e
+discard k e = discard (k - 1) (snd (next e))
+
+-- | The heavier "strong" Cromulent variant.
+data StrongEngine = StrongEngine !Word64 !Word64
+  deriving (Eq, Show)
+
+mkStrongEngine :: Word64 -> StrongEngine
+mkStrongEngine seed = let (a, b) = seedExpand seed in StrongEngine a b
+
+strongNext :: StrongEngine -> (Word64, StrongEngine)
+strongNext (StrongEngine a0 b0) = (mixFast output, StrongEngine a' b')
+  where
+    b1 = b0 + rotateL a0 13
+    a1 = rotateL a0 29 * c1 + b1
+    b2 = rotateL b1 17 `xor` a1
+    a2 = a1 + rotateL (b2 * c2) 31
+    b3 = b2 + rotateL a2 23
+    a3 = rotateL (a2 `xor` b3) 52
+    output = a3 + rotateL b3 41
+    a' = a3 + c1
+    b' = b3 `xor` (a3 `shiftR` 17)
+
+strongDiscard :: Word64 -> StrongEngine -> StrongEngine
+strongDiscard 0 e = e
+strongDiscard k e = strongDiscard (k - 1) (snd (strongNext e))

--- a/bindings/haskell/test/Spec.hs
+++ b/bindings/haskell/test/Spec.hs
@@ -1,0 +1,81 @@
+-- Self-contained test for the Haskell Cromulent port. Verifies bit-for-bit
+-- parity with the C reference vectors and basic range/discard behavior.
+module Main (main) where
+
+import Cromulent
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.List (foldl')
+import Data.Word (Word64)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStrLn, stderr)
+
+engineRef :: [Word64]
+engineRef =
+  [ 0x8b0849848b39737d, 0x829ecfb661e3a84d, 0x6cfb2afb89b5dc83
+  , 0x8ad5c0d490669f95, 0x8d4459e6318f2474, 0xa0b907b845990f61
+  , 0x2143675f2f4ff1ec, 0x38fff6f9c33c4f8f ]
+
+strongRef :: [Word64]
+strongRef =
+  [ 0xa1e9fb73cc5c77fa, 0xd8bc61a96accc72e, 0x3f98dad0bcb1c8f3
+  , 0xb179513c44fe1f0a, 0x413b884be5b9955f, 0x4b682d94916239a1
+  , 0xe7b93a4600d77791, 0x6a54f95b111a3555 ]
+
+-- Produce the first n outputs of an engine.
+takeN :: Int -> Engine -> [Word64]
+takeN 0 _ = []
+takeN k e = let (x, e') = next e in x : takeN (k - 1) e'
+
+takeStrong :: Int -> StrongEngine -> [Word64]
+takeStrong 0 _ = []
+takeStrong k e = let (x, e') = strongNext e in x : takeStrong (k - 1) e'
+
+main :: IO ()
+main = do
+  failures <- newIORef (0 :: Int)
+  let check cond msg =
+        if cond then pure () else do
+          hPutStrLn stderr ("FAIL: " ++ msg)
+          modifyIORef' failures (+ 1)
+
+  putStrLn "Running Cromulent Haskell engine tests"
+
+  putStr "Testing engine matches C reference... "
+  check (takeN 8 (mkEngine 0x0123456789ABCDEF) == engineRef) "engine outputs"
+  putStrLn "OK"
+
+  putStr "Testing strong engine matches C reference... "
+  check (takeStrong 8 (mkStrongEngine 0x0123456789ABCDEF) == strongRef) "strong outputs"
+  putStrLn "OK"
+
+  putStr "Testing nextDouble range... "
+  let (d0, e1) = nextDouble (mkEngine 42)
+  check (abs (d0 - 0.42990649088115307) < 1e-15) "first double"
+  let doubles = takeDoubles 10000 e1
+  check (all (\v -> v >= 0.0 && v < 1.0) doubles) "doubles in range"
+  putStrLn "OK"
+
+  putStr "Testing bounded range... "
+  let bs = takeBounded 10000 7 (mkEngine 99)
+  check (all (< 7) bs) "bounded < 7"
+  check (fst (bounded 0 (mkEngine 99)) == 0) "bounded 0"
+  putStrLn "OK"
+
+  putStr "Testing discard equivalence... "
+  let ea = discard 50 (mkEngine 555)
+      eb = foldl' (\e _ -> snd (next e)) (mkEngine 555) [1 .. 50 :: Int]
+  check (takeN 100 ea == takeN 100 eb) "discard n == n calls"
+  putStrLn "OK"
+
+  n <- readIORef failures
+  if n == 0
+    then putStrLn "All Haskell engine tests passed successfully!" >> exitSuccess
+    else putStrLn (show n ++ " check(s) failed!") >> exitFailure
+
+takeDoubles :: Int -> Engine -> [Double]
+takeDoubles 0 _ = []
+takeDoubles k e = let (d, e') = nextDouble e in d : takeDoubles (k - 1) e'
+
+takeBounded :: Int -> Word64 -> Engine -> [Word64]
+takeBounded 0 _ _ = []
+takeBounded k n e = let (v, e') = bounded n e in v : takeBounded (k - 1) n e'


### PR DESCRIPTION
## Summary

A dependency-free (base-only) Haskell port of the scalar Cromulent generator under `bindings/haskell/`.

- The engines are **pure**: each step returns the output together with the next state (`next :: Engine -> (Word64, Engine)`).
- `Engine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant. `Word64` arithmetic is modular, matching C. `bounded` uses `Integer` for the 128-bit product.

## Verification
`runghc -isrc test/Spec.hs` (uses only `base`, no build tool). Self-tests against shared reference vectors plus double-range, bounded, and discard-equivalence. Passes locally on GHC 9.4.

Self-contained (own `bindings/haskell/` sources + Haskell CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_