### PR TITLE
Add Julia port

### DIFF
--- a/.github/workflows/julia.yml
+++ b/.github/workflows/julia.yml
@@ -1,0 +1,22 @@
+name: Julia
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/julia/**', '.github/workflows/julia.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/julia/**', '.github/workflows/julia.yml' ]
+
+jobs:
+  test:
+    name: julia
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - name: Test
+        working-directory: bindings/julia
+        run: julia test/runtests.jl

--- a/bindings/julia/README.md
+++ b/bindings/julia/README.md
@@ -1,0 +1,22 @@
+# Cromulent PRNG — Julia
+
+A dependency-free Julia port of the scalar Cromulent generator. `Engine`
+reproduces the C reference stream (`cromulent_init` / `cromulent_next`)
+bit-for-bit; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
+`UInt64` arithmetic wraps at 2^64, matching the C generator, and `widemul`
+provides the 128-bit product for `bounded!` (Lemire's method).
+
+```julia
+include("src/Cromulent.jl"); using .Cromulent
+
+rng = Engine(0x0123456789ABCDEF)
+next_u64!(rng)        # UInt64
+next_double!(rng)     # [0, 1)
+bounded!(rng, UInt64(6))  # unbiased [0, 6)
+```
+
+## Test
+
+```bash
+julia test/runtests.jl
+```

--- a/bindings/julia/src/Cromulent.jl
+++ b/bindings/julia/src/Cromulent.jl
@@ -1,0 +1,125 @@
+"""
+The Cromulent PRNG -- a Julia port of the scalar reference generator.
+
+`Engine` reproduces the identical 64-bit stream as the C reference
+implementation (`cromulent_init` / `cromulent_next`) for any given seed;
+`StrongEngine` mirrors the heavier `cromulent_strong` variant. Julia's `UInt64`
+arithmetic wraps at 2^64, matching the C generator.
+"""
+module Cromulent
+
+export Engine, StrongEngine, next_u64!, next_double!, bounded!, discard!, default_seed
+
+const C1 = 0x9e3779b97f4a7c15
+const C2 = 0xbf58476d1ce4e5b9
+const C3 = 0x94d049bb133111eb
+const C6 = 0xd1342543de82ef95
+const MH3 = 0xd6e8feb86659fd93
+
+"Default seed, shared with the C library."
+const default_seed = 0x853c49e6748fea9b
+
+@inline function mix_fast(x::UInt64)
+    x ⊻= x >> 32
+    x *= MH3
+    x ⊻= x >> 32
+    return x
+end
+
+"SplitMix64-style seed expansion, matching cromulent_init."
+function seed_expand(seed::UInt64)
+    z = seed
+    out = Vector{UInt64}(undef, 2)
+    for i in 1:2
+        z += C1
+        z = (z ⊻ (z >> 30)) * C2
+        z = (z ⊻ (z >> 27)) * C3
+        out[i] = z ⊻ (z >> 31)
+    end
+    return (out[1], out[2])
+end
+
+"The primary Cromulent engine."
+mutable struct Engine
+    s0::UInt64
+    s1::UInt64
+end
+
+Engine(seed::UInt64 = default_seed) = Engine(seed_expand(seed)...)
+
+"Advance the state and return the next 64-bit output."
+function next_u64!(e::Engine)
+    s0 = e.s0
+    s1 = e.s1
+
+    e.s0 = s0 * C6 + s1
+    e.s1 = bitrotate(s1, 31) + mix_fast(s0)
+
+    r = s0 + bitrotate(s1, 11)
+    r ⊻= r >> 27
+    r *= C3
+    r ⊻= r >> 27
+    return r
+end
+
+"Uniform Float64 in [0, 1) using the top 53 bits."
+next_double!(e::Engine) = Float64(next_u64!(e) >> 11) * (1.0 / 9007199254740992.0)
+
+"Unbiased uniform integer in [0, n) via Lemire's method. Returns 0 when n == 0."
+function bounded!(e::Engine, n::UInt64)
+    n == 0 && return UInt64(0)
+    m = widemul(next_u64!(e), n)
+    low = m % UInt64
+    hi = (m >> 64) % UInt64
+    if low < n
+        threshold = (-n) % n
+        while low < threshold
+            m = widemul(next_u64!(e), n)
+            low = m % UInt64
+            hi = (m >> 64) % UInt64
+        end
+    end
+    return hi
+end
+
+"Advance the stream by z steps, discarding the output."
+function discard!(e::Engine, z::Integer)
+    for _ in 1:z
+        next_u64!(e)
+    end
+end
+
+"The heavier \"strong\" Cromulent variant."
+mutable struct StrongEngine
+    a::UInt64
+    b::UInt64
+end
+
+StrongEngine(seed::UInt64 = default_seed) = StrongEngine(seed_expand(seed)...)
+
+function next_u64!(e::StrongEngine)
+    a = e.a
+    b = e.b
+
+    b += bitrotate(a, 13)
+    a = bitrotate(a, 29) * C1 + b
+    b = bitrotate(b, 17) ⊻ a
+    a += bitrotate(b * C2, 31)
+    b += bitrotate(a, 23)
+    a = bitrotate(a ⊻ b, 52)
+
+    output = a + bitrotate(b, 41)
+
+    e.a = a + C1
+    e.b = b ⊻ (a >> 17)
+
+    return mix_fast(output)
+end
+
+function discard!(e::StrongEngine, z::Integer)
+    for _ in 1:z
+        next_u64!(e)
+    end
+end
+
+end # module

--- a/bindings/julia/test/runtests.jl
+++ b/bindings/julia/test/runtests.jl
@@ -1,0 +1,63 @@
+# Self-contained test for the Julia Cromulent port. Verifies bit-for-bit parity
+# with the C reference vectors and basic range/discard behavior.
+# Run with: julia test/runtests.jl  (from bindings/julia)
+
+include("../src/Cromulent.jl")
+
+using .Cromulent
+using Test
+
+const ENGINE_REF = UInt64[
+    0x8b0849848b39737d, 0x829ecfb661e3a84d, 0x6cfb2afb89b5dc83,
+    0x8ad5c0d490669f95, 0x8d4459e6318f2474, 0xa0b907b845990f61,
+    0x2143675f2f4ff1ec, 0x38fff6f9c33c4f8f,
+]
+
+const STRONG_REF = UInt64[
+    0xa1e9fb73cc5c77fa, 0xd8bc61a96accc72e, 0x3f98dad0bcb1c8f3,
+    0xb179513c44fe1f0a, 0x413b884be5b9955f, 0x4b682d94916239a1,
+    0xe7b93a4600d77791, 0x6a54f95b111a3555,
+]
+
+@testset "Cromulent" begin
+    @testset "engine matches C reference" begin
+        e = Engine(0x0123456789ABCDEF)
+        for want in ENGINE_REF
+            @test next_u64!(e) == want
+        end
+    end
+
+    @testset "strong engine matches C reference" begin
+        s = StrongEngine(0x0123456789ABCDEF)
+        for want in STRONG_REF
+            @test next_u64!(s) == want
+        end
+    end
+
+    @testset "next_double in range" begin
+        d = Engine(UInt64(42))
+        @test abs(next_double!(d) - 0.42990649088115307) < 1e-15
+        for _ in 1:10000
+            v = next_double!(d)
+            @test 0.0 <= v < 1.0
+        end
+    end
+
+    @testset "bounded in range" begin
+        b = Engine(UInt64(99))
+        @test bounded!(b, UInt64(0)) == 0
+        for _ in 1:10000
+            @test bounded!(b, UInt64(7)) < 7
+        end
+    end
+
+    @testset "discard equivalence" begin
+        a1 = Engine(UInt64(555))
+        a2 = Engine(UInt64(555))
+        discard!(a1, 50)
+        for _ in 1:50
+            next_u64!(a2)
+        end
+        @test a1.s0 == a2.s0 && a1.s1 == a2.s1
+    end
+end


### PR DESCRIPTION
## Summary

A dependency-free Julia port of the scalar Cromulent generator under `bindings/julia/`.

- `Engine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
- Native `UInt64` (wraps at 2^64), `bitrotate`, and `widemul` for the 128-bit product in `bounded!` (Lemire's method). Also `next_double!` and `discard!`.

## Verification
`julia test/runtests.jl` — `Test`-stdlib testset covering parity against shared reference vectors plus double-range, bounded, and discard-equivalence. Targets Julia 1.x.

> ⚠️ **Not executed locally:** the Julia toolchain is not installable in this environment (no Ubuntu-archive package and julialang.org downloads are blocked by egress policy), so this port has not been run here — it was written to match the algorithm already verified bit-for-bit in the C, Rust, and 9 other language ports. **CI is the first real execution;** please confirm the Julia job passes before merging (happy to fix anything it surfaces).

Self-contained (own `bindings/julia/` sources + Julia CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_