### PR TITLE
Add Swift port

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,20 @@
+name: Swift
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bindings/swift/**', '.github/workflows/swift.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'bindings/swift/**', '.github/workflows/swift.yml' ]
+
+jobs:
+  test:
+    name: swift run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v2
+      - name: Test
+        working-directory: bindings/swift
+        run: swift run -c release

--- a/bindings/swift/.gitignore
+++ b/bindings/swift/.gitignore
@@ -1,0 +1,3 @@
+.build/
+*.xcodeproj
+Package.resolved

--- a/bindings/swift/Package.swift
+++ b/bindings/swift/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "cromulent",
+    targets: [
+        .executableTarget(
+            name: "cromulent",
+            path: "Sources/cromulent"
+        )
+    ]
+)

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -1,0 +1,22 @@
+# Cromulent PRNG — Swift
+
+A dependency-free Swift port of the scalar Cromulent generator. `Engine`
+reproduces the C reference stream (`cromulent_init` / `cromulent_next`)
+bit-for-bit; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
+Uses native `UInt64` with the wrapping operators (`&+`, `&-`, `&*`) and
+`multipliedFullWidth(by:)` for the unbiased `bounded` (Lemire's method).
+
+```swift
+var rng = Engine(seed: 0x0123456789ABCDEF)
+let x = rng.next()          // UInt64
+let d = rng.nextDouble()    // [0, 1)
+let r = rng.bounded(6)      // unbiased [0, 6)
+```
+
+## Test
+
+The executable target runs the self-test:
+
+```bash
+swift run
+```

--- a/bindings/swift/Sources/cromulent/Cromulent.swift
+++ b/bindings/swift/Sources/cromulent/Cromulent.swift
@@ -1,0 +1,134 @@
+// The Cromulent PRNG — a Swift port of the scalar reference generator.
+//
+// `Engine` reproduces the identical 64-bit stream as the C reference
+// implementation (cromulent_init / cromulent_next) for any given seed;
+// `StrongEngine` mirrors the heavier cromulent_strong variant. Swift's UInt64
+// is a native unsigned type; the wrapping operators (&+, &-, &*) reproduce the
+// mod-2^64 arithmetic of the C generator.
+
+private let C1: UInt64 = 0x9e37_79b9_7f4a_7c15
+private let C2: UInt64 = 0xbf58_476d_1ce4_e5b9
+private let C3: UInt64 = 0x94d0_49bb_1331_11eb
+private let C6: UInt64 = 0xd134_2543_de82_ef95
+private let MH3: UInt64 = 0xd6e8_feb8_6659_fd93
+
+/// Default seed, shared with the C library.
+public let defaultSeed: UInt64 = 0x853c_49e6_748f_ea9b
+
+@inline(__always)
+private func rotl(_ x: UInt64, _ k: Int) -> UInt64 {
+    return (x << k) | (x >> (64 - k))
+}
+
+@inline(__always)
+private func mixFast(_ x0: UInt64) -> UInt64 {
+    var x = x0
+    x ^= x >> 32
+    x = x &* MH3
+    x ^= x >> 32
+    return x
+}
+
+/// SplitMix64-style seed expansion, matching cromulent_init.
+private func seedExpand(_ seed: UInt64) -> (UInt64, UInt64) {
+    var z = seed
+    var out = [UInt64](repeating: 0, count: 2)
+    for i in 0..<2 {
+        z = z &+ C1
+        z = (z ^ (z >> 30)) &* C2
+        z = (z ^ (z >> 27)) &* C3
+        out[i] = z ^ (z >> 31)
+    }
+    return (out[0], out[1])
+}
+
+/// The primary Cromulent engine.
+public struct Engine {
+    public private(set) var s0: UInt64
+    public private(set) var s1: UInt64
+
+    public init(seed: UInt64 = defaultSeed) {
+        (s0, s1) = seedExpand(seed)
+    }
+
+    /// Advance the state and return the next 64-bit output.
+    public mutating func next() -> UInt64 {
+        let a = s0
+        let b = s1
+
+        s0 = a &* C6 &+ b
+        s1 = rotl(b, 31) &+ mixFast(a)
+
+        var r = a &+ rotl(b, 11)
+        r ^= r >> 27
+        r = r &* C3
+        r ^= r >> 27
+        return r
+    }
+
+    /// Uniform Double in [0, 1) using the top 53 bits.
+    public mutating func nextDouble() -> Double {
+        return Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+
+    /// Unbiased uniform integer in [0, n) via Lemire's method. Returns 0 when n == 0.
+    public mutating func bounded(_ n: UInt64) -> UInt64 {
+        if n == 0 { return 0 }
+        var (hi, low) = next().multipliedFullWidth(by: n)
+        if low < n {
+            let threshold = (0 &- n) % n
+            while low < threshold {
+                (hi, low) = next().multipliedFullWidth(by: n)
+            }
+        }
+        return hi
+    }
+
+    /// Advance the stream by z steps, discarding the output.
+    public mutating func discard(_ z: UInt64) {
+        var i: UInt64 = 0
+        while i < z {
+            _ = next()
+            i &+= 1
+        }
+    }
+}
+
+/// The heavier "strong" Cromulent variant.
+public struct StrongEngine {
+    public private(set) var a: UInt64
+    public private(set) var b: UInt64
+
+    public init(seed: UInt64 = defaultSeed) {
+        (a, b) = seedExpand(seed)
+    }
+
+    public mutating func next() -> UInt64 {
+        var x = a
+        var y = b
+
+        y = y &+ rotl(x, 13)
+        x = rotl(x, 29) &* C1 &+ y
+
+        y = rotl(y, 17) ^ x
+        x = x &+ rotl(y &* C2, 31)
+
+        y = y &+ rotl(x, 23)
+        x = rotl(x ^ y, 52)
+
+        let output = x &+ rotl(y, 41)
+
+        a = x &+ C1
+        b = y ^ (x >> 17)
+
+        return mixFast(output)
+    }
+
+    public mutating func discard(_ z: UInt64) {
+        var i: UInt64 = 0
+        while i < z {
+            _ = next()
+            i &+= 1
+        }
+    }
+}

--- a/bindings/swift/Sources/cromulent/main.swift
+++ b/bindings/swift/Sources/cromulent/main.swift
@@ -1,0 +1,78 @@
+// Self-contained test runner for the Swift Cromulent port. Verifies bit-for-bit
+// parity with the C reference vectors and basic range/discard behavior. Exits
+// non-zero on failure.
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+let engineRef: [UInt64] = [
+    0x8b0849848b39737d, 0x829ecfb661e3a84d, 0x6cfb2afb89b5dc83,
+    0x8ad5c0d490669f95, 0x8d4459e6318f2474, 0xa0b907b845990f61,
+    0x2143675f2f4ff1ec, 0x38fff6f9c33c4f8f,
+]
+
+let strongRef: [UInt64] = [
+    0xa1e9fb73cc5c77fa, 0xd8bc61a96accc72e, 0x3f98dad0bcb1c8f3,
+    0xb179513c44fe1f0a, 0x413b884be5b9955f, 0x4b682d94916239a1,
+    0xe7b93a4600d77791, 0x6a54f95b111a3555,
+]
+
+var failures = 0
+func check(_ cond: Bool, _ msg: String) {
+    if !cond {
+        fputs("FAIL: \(msg)\n", stderr)
+        failures += 1
+    }
+}
+
+print("Running Cromulent Swift engine tests")
+
+print("Testing engine matches C reference... ", terminator: "")
+var e = Engine(seed: 0x0123456789ABCDEF)
+for (i, want) in engineRef.enumerated() {
+    check(e.next() == want, "engine output \(i)")
+}
+print("OK")
+
+print("Testing strong engine matches C reference... ", terminator: "")
+var s = StrongEngine(seed: 0x0123456789ABCDEF)
+for (i, want) in strongRef.enumerated() {
+    check(s.next() == want, "strong output \(i)")
+}
+print("OK")
+
+print("Testing nextDouble range... ", terminator: "")
+var d = Engine(seed: 42)
+check(abs(d.nextDouble() - 0.42990649088115307) < 1e-15, "first double")
+for _ in 0..<10000 {
+    let v = d.nextDouble()
+    check(v >= 0.0 && v < 1.0, "double in range")
+}
+print("OK")
+
+print("Testing bounded range... ", terminator: "")
+var b = Engine(seed: 99)
+check(b.bounded(0) == 0, "bounded(0)")
+for _ in 0..<10000 {
+    check(b.bounded(7) < 7, "bounded(7) < 7")
+}
+print("OK")
+
+print("Testing discard equivalence... ", terminator: "")
+var a1 = Engine(seed: 555)
+var a2 = Engine(seed: 555)
+a1.discard(50)
+for _ in 0..<50 { _ = a2.next() }
+check(a1.s0 == a2.s0 && a1.s1 == a2.s1, "discard(n) == n calls")
+print("OK")
+
+if failures == 0 {
+    print("All Swift engine tests passed successfully!")
+    exit(0)
+} else {
+    print("\(failures) check(s) failed!")
+    exit(1)
+}


### PR DESCRIPTION
## Summary

A dependency-free Swift port of the scalar Cromulent generator under `bindings/swift/`.

- `Engine` reproduces the C reference stream (`cromulent_init` / `cromulent_next`) **bit-for-bit**; `StrongEngine` mirrors the heavier `cromulent_strong` variant.
- Native `UInt64` with the wrapping operators (`&+`, `&-`, `&*`) and `multipliedFullWidth(by:)` for the unbiased `bounded` (Lemire's method). Also `nextDouble` and `discard`.

## Verification
`swift run` (executable target runs the self-test): parity against shared reference vectors plus double-range, bounded, and discard-equivalence.

> ⚠️ **Not executed locally:** the Swift toolchain is not installable in this environment (no Ubuntu-archive package and swift.org downloads are blocked by egress policy), so this port has not been run here — it was written to match the algorithm already verified bit-for-bit in the C, Rust, and 10 other language ports. **CI is the first real execution;** please confirm the Swift job passes before merging (happy to fix anything it surfaces).

Self-contained (own `bindings/swift/` package + Swift CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dvorfhD8hhzRE9gNbJPQ6)_